### PR TITLE
Review code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,12 @@
 version: 2
 
 jobs:
+  formatting:
+    docker:
+      - image: moia/scala-on-circleci:java8-scala2.13
+    steps:
+      - checkout
+      - run: sbt "scalafmtCheckAll"
   test:
     docker:
       - image: moia/scala-on-circleci:java8-scala2.13
@@ -47,5 +53,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - formatting
       - test
       - scapegoat

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ implicit val executionContext: ExecutionContext = system.dispatcher
 
 val httpClientConfig: HttpClientConfig = HttpClientConfig("http", isSecureConnection = false, "127.0.0.1", 8888)
 val clock: Clock                       = Clock.systemUTC()
-val httpMetrics: HttpMetrics[String]   = new HttpMetrics[String] {
-  override def meterResponse(method: HttpMethod, path: Uri.Path, response: HttpResponse)(implicit ctx: String): Unit = ()
+val httpMetrics: HttpMetrics[NoLoggingContext]   = new HttpMetrics[NoLoggingContext] {
+  override def meterResponse(method: HttpMethod, path: Uri.Path, response: HttpResponse)(implicit ctx: NoLoggingContext): Unit = ()
 }
 val retryConfig: RetryConfig =
     RetryConfig(

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= akkaDependencies ++ awsDependencies ++ testDependencies ++ loggingDependencies ++ otherDependencies
   )
   .settings(sonatypeSettings: _*)
+  .settings(
+    scalafmtOnCompile := true
+  )
 
 val akkaVersion     = "2.5.29"
 val akkaHttpVersion = "10.1.11"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "scala-http-client",
     organization := "io.moia",
-    version := "1.1.0",
+    version := "1.2.0-SNAPSHOT",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(ScmInfo(url("https://github.com/moia-dev/scala-http-client"), "scm:git@github.com:moia-dev/scala-http-client.git")),
     homepage := Some(url("https://github.com/moia-dev/scala-http-client")),

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "scala-http-client",
     organization := "io.moia",
-    version := "1.1.0-akka2.5",
+    version := "1.1.0",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(ScmInfo(url("https://github.com/moia-dev/scala-http-client"), "scm:git@github.com:moia-dev/scala-http-client.git")),
     homepage := Some(url("https://github.com/moia-dev/scala-http-client")),

--- a/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
@@ -25,9 +25,14 @@ class HttpClient(
     awsRequestSigner: Option[AwsRequestSigner]
 )(
     implicit system: ActorSystem
-) extends LoggingHttpClient[String](config, gatewayType, httpMetrics, retryConfig, clock, awsRequestSigner)(
-      system,
-      Logger.takingImplicit(LoggerFactory.getLogger(getClass.getName))((msg: String, _: String) => msg)
+) extends LoggingHttpClient[String](
+      config,
+      gatewayType,
+      httpMetrics,
+      retryConfig,
+      clock,
+      Logger.takingImplicit(LoggerFactory.getLogger(getClass.getName))((msg: String, _: String) => msg),
+      awsRequestSigner
     ) {
   override def request(
       method: HttpMethod,
@@ -46,9 +51,10 @@ class LoggingHttpClient[LoggingContext](
     httpMetrics: HttpMetrics[LoggingContext],
     retryConfig: RetryConfig,
     clock: Clock,
+    logger: LoggerTakingImplicit[LoggingContext],
     awsRequestSigner: Option[AwsRequestSigner]
-)(implicit system: ActorSystem, logger: LoggerTakingImplicit[LoggingContext])
-    extends HttpLayer(config, gatewayType, httpMetrics, retryConfig, clock, awsRequestSigner) {
+)(implicit system: ActorSystem)
+    extends HttpLayer(config, gatewayType, httpMetrics, retryConfig, clock, logger, awsRequestSigner) {
   override protected def sendRequest: HttpRequest => Future[HttpResponse] = Http().singleRequest(_)
 }
 
@@ -58,10 +64,10 @@ abstract class HttpLayer[LoggingContext](
     httpMetrics: HttpMetrics[LoggingContext],
     retryConfig: RetryConfig,
     clock: Clock,
+    logger: LoggerTakingImplicit[LoggingContext],
     awsRequestSigner: Option[AwsRequestSigner] = None
 )(
-    implicit system: ActorSystem,
-    logger: LoggerTakingImplicit[LoggingContext]
+    implicit system: ActorSystem
 ) {
 
   protected def sendRequest: HttpRequest => Future[HttpResponse]

--- a/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
@@ -60,7 +60,7 @@ class LoggingHttpClient[LoggingContext](
 
 abstract class HttpLayer[LoggingContext](
     config: HttpClientConfig,
-    val name: String,
+    name: String,
     httpMetrics: HttpMetrics[LoggingContext],
     retryConfig: RetryConfig,
     clock: Clock,

--- a/src/main/scala/io/moia/scalaHttpClient/NoLoggingContext.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/NoLoggingContext.scala
@@ -1,0 +1,6 @@
+package io.moia.scalaHttpClient
+
+trait NoLoggingContext
+object NoLoggingContext extends NoLoggingContext {
+  implicit val noLoggingContext: NoLoggingContext = NoLoggingContext
+}

--- a/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
@@ -32,7 +32,7 @@ class LoggingHttpClientTest extends TestSetup {
       } else MDC.remove("context")
   }
 
-  private implicit val theLogger: LoggerTakingImplicit[LoggingContext] = Logger.takingImplicit(LoggerFactory.getLogger(getClass.getName))
+  private val theLogger: LoggerTakingImplicit[LoggingContext] = Logger.takingImplicit(LoggerFactory.getLogger(getClass.getName))
   private implicit val ctx: LoggingContext                             = LoggingContext("Logging Context")
 
   classOf[LoggingHttpClient[LoggingContext]].getSimpleName should {

--- a/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
@@ -33,7 +33,7 @@ class LoggingHttpClientTest extends TestSetup {
   }
 
   private val theLogger: LoggerTakingImplicit[LoggingContext] = Logger.takingImplicit(LoggerFactory.getLogger(getClass.getName))
-  private implicit val ctx: LoggingContext                             = LoggingContext("Logging Context")
+  private implicit val ctx: LoggingContext                    = LoggingContext("Logging Context")
 
   classOf[LoggingHttpClient[LoggingContext]].getSimpleName should {
     "take a customer logger" in {

--- a/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
@@ -39,7 +39,7 @@ class LoggingHttpClientTest extends TestSetup {
     "take a customer logger" in {
       // given
       val testHttpClient =
-        new LoggingHttpClient[LoggingContext](httpClientConfig, "TestGateway", typedHttpMetrics, retryConfig, clock, None) {
+        new LoggingHttpClient[LoggingContext](httpClientConfig, "TestGateway", typedHttpMetrics, retryConfig, clock, theLogger, None) {
           override def sendRequest: HttpRequest => Future[HttpResponse] = (_: HttpRequest) => Future.successful(HttpResponse())
         }
 

--- a/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
@@ -17,8 +17,8 @@ trait TestSetup extends AnyWordSpecLike with Matchers with FutureValues {
   implicit val executionContext: ExecutionContext = system.dispatcher
 
   val clock: Clock = Clock.systemUTC()
-  val httpMetrics: HttpMetrics[String] = new HttpMetrics[String] {
-    override def meterResponse(method: HttpMethod, path: Uri.Path, response: HttpResponse)(implicit ctx: String): Unit = ()
+  val httpMetrics: HttpMetrics[NoLoggingContext] = new HttpMetrics[NoLoggingContext] {
+    override def meterResponse(method: HttpMethod, path: Uri.Path, response: HttpResponse)(implicit ctx: NoLoggingContext): Unit = ()
   }
 
   val httpClientConfig: HttpClientConfig = HttpClientConfig("http", isSecureConnection = false, "127.0.0.1", 8888)


### PR DESCRIPTION
Changes:

- introduce `NoLoggingContext` type and remove `String` as No-Op
- use scalafmt in sbt to keep everything formatted
- check scalafmt in CircleCI (otherwise line numbers in stacktraces don't line up)
- remove akka2.5 version suffix
- renamed `gatewayType` to `name` because the gateway concept is not necessary in this lib
- don't pass around the logger as an implicit in class ctor