### PR TITLE
Refine retry-configuration for 502, 4xx and 5xx

### DIFF
--- a/src/main/scala/io/moia/scalaHttpClient/HttpClientConfig.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/HttpClientConfig.scala
@@ -21,11 +21,31 @@ final case class HttpClientConfig(
 
 /**
   * Retry configuration of HTTP clients.
+  *
+  * @param retriesRequestTimeout Number of retries for HTTP 408
+  * @param retriesTooManyRequests Number of retries for HTTP 429 (usually in combination with retry-after header)
+  * @param retriesClientError Number of retries for all other 4xx codes
+  * @param retriesInternalServerError Number of retries for HTTP 500
+  * @param retriesBadGateway Number of retries for HTTP 502
+  * @param retriesServiceUnavailable Number of retries for HTTP 503
+  * @param retriesServerError Number of retries for all other 5xx codes
+  * @param retriesException Number of retries for exceptions in the underlying akka-http client
+  * @param initialBackoff Time to wait until the first retry. Is multiplied with 2^(# of retry).
+  *                       Example:
+  *                       10ms * 2^0 => 10ms
+  *                       10ms * 2^1 => 20ms
+  *                       10ms * 2^2 => 40ms
+  *                       10ms * 2^3 => 80ms
+  *                       10ms * 2^4 => 160ms
+  * @param strictifyResponseTimeout Time to wait for streaming data to complete
   */
 final case class RetryConfig(
-    retriesTooManyRequests: Int,
-    retriesServiceUnavailable: Int,
     retriesRequestTimeout: Int,
+    retriesTooManyRequests: Int,
+    retriesClientError: Int,
+    retriesInternalServerError: Int,
+    retriesBadGateway: Int,
+    retriesServiceUnavailable: Int,
     retriesServerError: Int,
     retriesException: Int,
     initialBackoff: FiniteDuration,
@@ -34,12 +54,15 @@ final case class RetryConfig(
 
 object RetryConfig {
   val default: RetryConfig = RetryConfig(
-    retriesTooManyRequests    = 2,
-    retriesServiceUnavailable = 3,
-    retriesRequestTimeout     = 1,
-    retriesServerError        = 3,
-    retriesException          = 3,
-    initialBackoff            = 10.millis,
-    strictifyResponseTimeout  = 1.second
+    retriesRequestTimeout      = 1,
+    retriesTooManyRequests     = 2,
+    retriesClientError         = 0,
+    retriesInternalServerError = 3,
+    retriesBadGateway          = 3,
+    retriesServiceUnavailable  = 3,
+    retriesServerError         = 3,
+    retriesException           = 3,
+    initialBackoff             = 10.millis,
+    strictifyResponseTimeout   = 1.second
   )
 }

--- a/src/test/scala/io/moia/scalaHttpClient/StatusCodesTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/StatusCodesTest.scala
@@ -11,23 +11,13 @@ import scala.concurrent.duration._
 
 class StatusCodesTest extends TestSetup with MockServer {
 
-  override val retryConfig: RetryConfig =
-    RetryConfig(
-      retriesTooManyRequests    = 2,
-      retriesServiceUnavailable = 2,
-      retriesRequestTimeout     = 2,
-      retriesServerError        = 2,
-      retriesException          = 3,
-      initialBackoff            = 10.millis,
-      strictifyResponseTimeout  = 1.second
-    )
-
   override implicit val defaultAwaitDuration: FiniteDuration = 1.second
 
   "respect retry configuration" when {
     s"the server responds with ${StatusCodes.TooManyRequests}" in {
       // Given
-      val httpClient = new HttpClient(mockServerHttpClientConfig, "TestGateway", httpMetrics, retryConfig, clock, None)
+      val retryConfig = RetryConfig.default.copy(retriesTooManyRequests = 2)
+      val httpClient  = new HttpClient(mockServerHttpClientConfig, "TestGateway", httpMetrics, retryConfig, clock, None)
 
       // status 429
       getClientAndServer
@@ -44,7 +34,8 @@ class StatusCodesTest extends TestSetup with MockServer {
     }
 
     s"the server responds with ${StatusCodes.ServiceUnavailable}" in {
-      val httpClient = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
+      val retryConfig = RetryConfig.default.copy(retriesServiceUnavailable = 2)
+      val httpClient  = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
 
       getClientAndServer
         .when(request().withPath("/test").withMethod("POST"), Times.unlimited())
@@ -60,7 +51,8 @@ class StatusCodesTest extends TestSetup with MockServer {
     }
 
     s"the server responds with ${StatusCodes.RequestTimeout}" in {
-      val httpClient = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
+      val retryConfig = RetryConfig.default.copy(retriesRequestTimeout = 2)
+      val httpClient  = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
 
       getClientAndServer
         .when(request().withPath("/test").withMethod("POST"), Times.unlimited())
@@ -76,7 +68,8 @@ class StatusCodesTest extends TestSetup with MockServer {
     }
 
     s"the server responds with ${StatusCodes.InternalServerError}" in {
-      val httpClient = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
+      val retryConfig = RetryConfig.default.copy(retriesInternalServerError = 2)
+      val httpClient  = new HttpClient(mockServerHttpClientConfig, "Dispatching2", httpMetrics, retryConfig, clock, None)
 
       getClientAndServer
         .when(request().withPath("/test").withMethod("POST"), Times.unlimited())

--- a/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
@@ -9,7 +9,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
 trait TestSetup extends AnyWordSpecLike with Matchers with FutureValues {
   implicit val system: ActorSystem                = ActorSystem("test")
@@ -23,14 +22,5 @@ trait TestSetup extends AnyWordSpecLike with Matchers with FutureValues {
 
   val httpClientConfig: HttpClientConfig = HttpClientConfig("http", "127.0.0.1", 8888)
 
-  val retryConfig: RetryConfig =
-    RetryConfig(
-      retriesTooManyRequests    = 2,
-      retriesServiceUnavailable = 0,
-      retriesRequestTimeout     = 0,
-      retriesServerError        = 0,
-      retriesException          = 3,
-      initialBackoff            = 10.millis,
-      strictifyResponseTimeout  = 1.second
-    )
+  val retryConfig: RetryConfig = RetryConfig.default
 }


### PR DESCRIPTION
Adds handling for HTTP 502 Bad Gateway and 4xx and 5xx in general.

Note that what was called `retriesServerError` before was _actually_ just code 500 _Internal_ Server Error. This is replaced by `retriesInternalServerError`.
The `retriesServerError` now applies to _all_ 5xx that aren't handled more specifically.