### PR TITLE
increase default timeout of FutureValue to a second

### DIFF
--- a/src/test/scala/io/moia/scalaHttpClient/FutureValues.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/FutureValues.scala
@@ -19,7 +19,7 @@ import scala.concurrent.{Await, Future, TimeoutException}
   * ```
   */
 trait FutureValues extends Assertions {
-  protected implicit val defaultAwaitDuration: FiniteDuration = 500.millis
+  protected implicit val defaultAwaitDuration: FiniteDuration = 1000.millis
 
   implicit class WithFutureValue[T](future: Future[T]) {
     def futureValue(implicit awaitDuration: Duration): T =


### PR DESCRIPTION
Increase the defaultTimeout of FutureValue to 1sec because in CI 500ms is sometimes a bit slow and test fails 🌵 

Signed-off-by: cristina <cristina.heredia@moia.io>