### PR TITLE
Use git tags for versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ lazy val root = (project in file("."))
   .settings(
     name := "scala-http-client",
     organization := "io.moia",
-    version := "1.3.1",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(ScmInfo(url("https://github.com/moia-dev/scala-http-client"), "scm:git@github.com:moia-dev/scala-http-client.git")),
     homepage := Some(url("https://github.com/moia-dev/scala-http-client")),
@@ -23,6 +22,11 @@ lazy val root = (project in file("."))
     scalafmtOnCompile := true,
     Defaults.itSettings,
     scalacOptions in IntegrationTest := (scalacOptions in Compile).value.filterNot(_ == "-Ywarn-dead-code")
+  )
+  .settings(sbtGitSettings)
+  .enablePlugins(
+    GitVersioning,
+    GitBranchPrompt
   )
 
 val akkaVersion     = "2.6.4"
@@ -93,3 +97,17 @@ lazy val sonatypeSettings = {
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
   )
 }
+
+lazy val sbtVersionRegex = "v([0-9]+.[0-9]+.[0-9]+)-?(.*)?".r
+
+lazy val sbtGitSettings = Seq(
+  git.useGitDescribe := true,
+  git.baseVersion := "0.0.0",
+  git.uncommittedSignifier := None,
+  git.gitTagToVersionNumber := {
+    case sbtVersionRegex(v, "")         => Some(v)
+    case sbtVersionRegex(v, "SNAPSHOT") => Some(s"$v-SNAPSHOT")
+    case sbtVersionRegex(v, s)          => Some(s"$v-$s-SNAPSHOT")
+    case _                              => None
+  }
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 
 // publishSigned
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Automatically uses the current `git tag` as version. So
* currently on tag `1.1.1` => version `1.1.1`
* one commit further => version `1.1.1-{num-of-commits}-{hash}`

See https://github.com/sbt/sbt-git