### PR TITLE
Use StsClient for AwsRequestSigner

### DIFF
--- a/src/main/scala/io/moia/scalaHttpClient/AwsRequestSigner.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/AwsRequestSigner.scala
@@ -14,6 +14,7 @@ import software.amazon.awssdk.auth.signer.{Aws4Signer, AwsSignerExecutionAttribu
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes
 import software.amazon.awssdk.http.{SdkHttpFullRequest, SdkHttpMethod}
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 
@@ -103,6 +104,7 @@ object AwsRequestSigner extends StrictLogging {
         logger.info(s"Assuming role from config $config.")
         val provider: StsAssumeRoleCredentialsProvider = StsAssumeRoleCredentialsProvider
           .builder()
+          .stsClient(StsClient.create())
           .refreshRequest(
             AssumeRoleRequest.builder().roleArn(roleArn).roleSessionName(roleSessionName).build()
           )


### PR DESCRIPTION
Version 2.1 led to the following error in https://github.com/moia-dev/trip-estimate/:
```
Assuming role from config AssumeRole(…). 
Exception in thread "main" java.lang.NullPointerException: STS client must not be null.
```

This should fix it by creating the `StsClient` for the `AwsRequestSigner`.