### PR TITLE
Update to Scapegoat 1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The lib outputs the following response objects (see `io.moia.scalaHttpClient.Htt
 * HTTP 400 Bad Request _without entity_ => `HttpClientError`
 * HTTP 4xx, 5xx, others => `HttpClientError`
 * if the deadline expired => `DeadlineExpired`
-* if an `AwsRequestSigner` is given, but the request already includes an "Authorization" header => `AlreadyAuthorized`
+* if an `AwsRequestSigner` is given, but the request already includes an "Authorization" header => `AlreadyAuthorizedException`
 * weird akka-errors => `ExceptionOccurred`
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val scalaDependencies = Seq(
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
 )
 
-scapegoatVersion in ThisBuild := "1.4.1"
+scapegoatVersion in ThisBuild := "1.4.4"
 
 lazy val scalacOptions_2_12 = Seq(
   "-unchecked",

--- a/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
+++ b/src/main/scala/io/moia/scalaHttpClient/HttpClient.scala
@@ -53,7 +53,7 @@ class LoggingHttpClient[LoggingContext](
     awsRequestSigner: Option[AwsRequestSigner]
 )(implicit system: ActorSystem)
     extends HttpLayer(config, name, httpMetrics, retryConfig, clock, logger, awsRequestSigner) {
-  override protected def sendRequest: HttpRequest => Future[HttpResponse] = Http().singleRequest(_)
+  override protected def sendRequest(req: HttpRequest): Future[HttpResponse] = Http().singleRequest(req)
 }
 
 abstract class HttpLayer[LoggingContext](
@@ -67,7 +67,7 @@ abstract class HttpLayer[LoggingContext](
 )(implicit
     system: ActorSystem
 ) {
-  protected def sendRequest: HttpRequest => Future[HttpResponse]
+  protected def sendRequest(req: HttpRequest): Future[HttpResponse]
 
   def request(
       method: HttpMethod,
@@ -112,19 +112,19 @@ abstract class HttpLayer[LoggingContext](
       .andThen(logResponse(request))
       .andThen(logRetryAfter)
       .flatMap(strictify)
-      .flatMap(handleResponse(tryNumber, deadline, request))
+      .flatMap(handleResponse(tryNumber, deadline, request)(_))
       .recoverWith(handleErrors(tryNumber, deadline, request))
 
   private[this] def handleResponse(tryNumber: Int, deadline: Deadline, httpRequest: HttpRequest)(
       response: HttpResponse
   )(implicit ec: ExecutionContext, ctx: LoggingContext): Future[HttpClientResponse] =
     response match {
-      case response @ HttpResponse(StatusCodes.Success(_), _, _, _)                => Future.successful(HttpClientSuccess(response))
-      case response @ HttpResponse(StatusCodes.BadRequest, _, HttpEntity.Empty, _) => Future.successful(HttpClientError(response))
-      case response @ HttpResponse(StatusCodes.BadRequest, _, _, _)                => Future.successful(DomainError(response))
-      case response @ HttpResponse(StatusCodes.ClientError(_), _, _, _)            => retryWithConfig(tryNumber, httpRequest, response, deadline)
-      case response @ HttpResponse(StatusCodes.ServerError(_), _, _, _)            => retryWithConfig(tryNumber, httpRequest, response, deadline)
-      case other                                                                   => Future.successful(HttpClientError(other))
+      case HttpResponse(StatusCodes.Success(_), _, _, _)                => Future.successful(HttpClientSuccess(response))
+      case HttpResponse(StatusCodes.BadRequest, _, HttpEntity.Empty, _) => Future.successful(HttpClientError(response))
+      case HttpResponse(StatusCodes.BadRequest, _, _, _)                => Future.successful(DomainError(response))
+      case HttpResponse(StatusCodes.ClientError(_), _, _, _)            => retryWithConfig(tryNumber, httpRequest, response, deadline)
+      case HttpResponse(StatusCodes.ServerError(_), _, _, _)            => retryWithConfig(tryNumber, httpRequest, response, deadline)
+      case other                                                        => Future.successful(HttpClientError(other))
     }
 
   private[this] def strictify(response: HttpResponse)(implicit ec: ExecutionContext): Future[HttpResponse] =

--- a/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/LoggingHttpClientTest.scala
@@ -39,7 +39,7 @@ class LoggingHttpClientTest extends TestSetup {
       // given
       val testHttpClient =
         new LoggingHttpClient[LoggingContext](httpClientConfig, "TestGateway", typedHttpMetrics, retryConfig, clock, theLogger, None) {
-          override def sendRequest: HttpRequest => Future[HttpResponse] = (_: HttpRequest) => Future.successful(HttpResponse())
+          override def sendRequest(req: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse())
         }
 
       // when


### PR DESCRIPTION
- Update Scapegoat to v1.4.4
- Avoid variable shadowing
- Change signature of `sendRequest`, so this is a breaking change => v3.0.0 needs to be released