### PR TITLE
Use Akka typed ActorSystem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ val akkaHttpVersion = "10.2.2"
 
 lazy val akkaDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream"       % akkaVersion,
+  "com.typesafe.akka" %% "akka-stream-typed" % akkaVersion,
   "com.typesafe.akka" %% "akka-http"         % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-testkit"      % akkaVersion     % Test,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test

--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,9 @@ lazy val awsDependencies = Seq(
 )
 
 lazy val testDependencies = Seq(
-  "org.scalatest"   %% "scalatest"       % "3.2.3"  % Test,
-  "org.mockito"     %% "mockito-scala"   % "1.16.12" % Test,
-  "org.mock-server" % "mockserver-netty" % "5.11.2" % Test
+  "org.scalatest"  %% "scalatest"        % "3.2.3"   % Test,
+  "org.mockito"    %% "mockito-scala"    % "1.16.12" % Test,
+  "org.mock-server" % "mockserver-netty" % "5.11.2"  % Test
 )
 
 lazy val loggingDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val awsDependencies = Seq(
 
 lazy val testDependencies = Seq(
   "org.scalatest"   %% "scalatest"       % "3.2.3"  % Test,
-  "org.mockito"     %% "mockito-scala"   % "1.16.3" % Test,
+  "org.mockito"     %% "mockito-scala"   % "1.16.12" % Test,
   "org.mock-server" % "mockserver-netty" % "5.11.2" % Test
 )
 

--- a/src/it/scala/io/moia/scalaHttpClient/HeaderExample.scala
+++ b/src/it/scala/io/moia/scalaHttpClient/HeaderExample.scala
@@ -1,13 +1,13 @@
 package io.moia.scalaHttpClient
 
-import java.time.Clock
-
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ModeledCustomHeader, ModeledCustomHeaderCompanion}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import io.moia.scalaHttpClient.ExampleModel.{DomainErrorObject, GatewayException, MySuccessObject}
 
+import java.time.Clock
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -24,9 +24,8 @@ object CustomHeader extends ModeledCustomHeaderCompanion[CustomHeader] {
 }
 
 object HeaderExample {
-
-  implicit val system: ActorSystem                                = ActorSystem("test")
-  implicit val executionContext: ExecutionContext                 = system.dispatcher
+  implicit val system: ActorSystem[_]                             = ActorSystem(Behaviors.empty, "test")
+  implicit val executionContext: ExecutionContext                 = system.executionContext
   implicit val um1: Unmarshaller[HttpResponse, MySuccessObject]   = ???
   implicit val um2: Unmarshaller[HttpResponse, DomainErrorObject] = ???
 

--- a/src/it/scala/io/moia/scalaHttpClient/LoggingExample.scala
+++ b/src/it/scala/io/moia/scalaHttpClient/LoggingExample.scala
@@ -1,18 +1,18 @@
 package io.moia.scalaHttpClient
 
-import java.time.Clock
-
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.model._
 import com.typesafe.scalalogging._
 import io.moia.scalaHttpClient.CustomLogging.LoggingContext
 import org.slf4j.LoggerFactory
 
+import java.time.Clock
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 object CustomLogging {
-  case class LoggingContext(context: String)
+  final case class LoggingContext(context: String)
 
   implicit val canLogString: CanLog[LoggingContext] = new CanLog[LoggingContext] {
     override def logMessage(originalMsg: String, ctx: LoggingContext): String = ???
@@ -23,8 +23,8 @@ object CustomLogging {
 }
 
 object Example {
-  implicit val system: ActorSystem                = ActorSystem("test")
-  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val system: ActorSystem[_]             = ActorSystem(Behaviors.empty, "test")
+  implicit val executionContext: ExecutionContext = system.executionContext
 
   // create the client
   val httpClient = new LoggingHttpClient[LoggingContext](

--- a/src/it/scala/io/moia/scalaHttpClient/SimpleExample.scala
+++ b/src/it/scala/io/moia/scalaHttpClient/SimpleExample.scala
@@ -1,25 +1,24 @@
 package io.moia.scalaHttpClient
 
-import java.time.Clock
-
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import io.moia.scalaHttpClient.ExampleModel.{DomainErrorObject, GatewayException, MySuccessObject}
 
+import java.time.Clock
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 object ExampleModel {
-  case class MySuccessObject(foo: String)
-  case class DomainErrorObject(errorMessage: String)
-  case class GatewayException(msg: String) extends RuntimeException(msg)
+  final case class MySuccessObject(foo: String)
+  final case class DomainErrorObject(errorMessage: String)
+  final case class GatewayException(msg: String) extends RuntimeException(msg)
 }
 
 object SimpleExample {
-
-  implicit val system: ActorSystem                                = ActorSystem("test")
-  implicit val executionContext: ExecutionContext                 = system.dispatcher
+  implicit val system: ActorSystem[_]                             = ActorSystem(Behaviors.empty, "test")
+  implicit val executionContext: ExecutionContext                 = system.executionContext
   implicit val um1: Unmarshaller[HttpResponse, MySuccessObject]   = ???
   implicit val um2: Unmarshaller[HttpResponse, DomainErrorObject] = ???
 

--- a/src/test/scala/io/moia/scalaHttpClient/StatusCodesTest.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/StatusCodesTest.scala
@@ -10,7 +10,6 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 
 class StatusCodesTest extends TestSetup with MockServer {
-
   override implicit val defaultAwaitDuration: FiniteDuration = 1.second
 
   "respect retry configuration" when {

--- a/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
+++ b/src/test/scala/io/moia/scalaHttpClient/TestSetup.scala
@@ -1,8 +1,8 @@
 package io.moia.scalaHttpClient
 
 import java.time.Clock
-
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.model.{HttpMethod, HttpResponse, Uri}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -10,8 +10,8 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.ExecutionContext
 
 trait TestSetup extends AnyWordSpecLike with Matchers with FutureValues {
-  implicit val system: ActorSystem                = ActorSystem("test")
-  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val system: ActorSystem[_]             = ActorSystem(Behaviors.empty, "test")
+  implicit val executionContext: ExecutionContext = system.executionContext
 
   val clock: Clock = Clock.systemUTC()
   val httpMetrics: HttpMetrics[NoLoggingContext] = new HttpMetrics[NoLoggingContext] {


### PR DESCRIPTION
With Akka 2.6 actors and streams are typed or untyped. Typed is the future, so we should also use it in this library.

The test is green on my local machine. It is flaky for every second PR (see e.g. #139).

I think this should be a new major version.

Signed-off-by: Bendix Saeltz <bendix@saeltz.de>